### PR TITLE
Changing the .net version from 4.5.1 to 4.5

### DIFF
--- a/NCode.Composition.DisposableParts.Signed/NCode.Composition.DisposableParts.Signed.csproj
+++ b/NCode.Composition.DisposableParts.Signed/NCode.Composition.DisposableParts.Signed.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NCode.Composition.DisposableParts</RootNamespace>
     <AssemblyName>NCode.Composition.DisposableParts.Signed</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/NCode.Composition.DisposableParts.Test/NCode.Composition.DisposableParts.Test.csproj
+++ b/NCode.Composition.DisposableParts.Test/NCode.Composition.DisposableParts.Test.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NCode.Composition.DisposableParts.Test</RootNamespace>
     <AssemblyName>NCode.Composition.DisposableParts.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/NCode.Composition.DisposableParts/NCode.Composition.DisposableParts.csproj
+++ b/NCode.Composition.DisposableParts/NCode.Composition.DisposableParts.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NCode.Composition.DisposableParts</RootNamespace>
     <AssemblyName>NCode.Composition.DisposableParts</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Hello,
A lot of my projects were in 4.5.  I am using Azure Cloud Service and the latest version they support is .net 4.5, that is why I had to change the library version instead of my cloud service project version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ncodegroup/ncode.composition.disposableparts/4)
<!-- Reviewable:end -->
